### PR TITLE
Modifikovani GrupaIntervencija JPA i rest, kao i status rest

### DIFF
--- a/stom-api/src/main/java/com/stom/app/ctrls/GrupaIntervencijaRestController.java
+++ b/stom-api/src/main/java/com/stom/app/ctrls/GrupaIntervencijaRestController.java
@@ -36,6 +36,15 @@ public class GrupaIntervencijaRestController {
 		return grupaIntervencijaRepository.findAll();
 	}
 	
+	@GetMapping(value = "/NextId")
+	public int getNextId() {
+		Integer sledeci = jdbcTemplate.queryForObject("SELECT max(id)+1 "
+													+ "FROM grupa_intervencija", Integer.class);
+		if (sledeci == null)
+			sledeci = new Integer(1);
+		return sledeci.intValue();
+	}
+	
 	@GetMapping(value = "/{id}")
 	public ResponseEntity<Void> get(@PathVariable("id") int id) {
 		Optional<GrupaIntervencija> obj = grupaIntervencijaRepository.findById(id);

--- a/stom-api/src/main/java/com/stom/app/ctrls/StatusRestController.java
+++ b/stom-api/src/main/java/com/stom/app/ctrls/StatusRestController.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,9 +27,21 @@ public class StatusRestController {
 	@Autowired
 	private StatusRepository statusRepository;
 	
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+	
 	@GetMapping
 	public Collection<Status> getAll() {
 		return statusRepository.findAll();
+	}
+	
+	@GetMapping(value = "NextId")
+	public int getNextId() {
+		Integer sledeci = jdbcTemplate.queryForObject("SELECT max(id)+1 "
+													+ "FROM status", Integer.class);
+		if(sledeci == null)
+			sledeci = new Integer(1);
+		return sledeci.intValue();
 	}
 	
 	@GetMapping(value = "/{id}")

--- a/stom-api/src/main/java/com/stom/app/jpa/GrupaIntervencija.java
+++ b/stom-api/src/main/java/com/stom/app/jpa/GrupaIntervencija.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 public class GrupaIntervencija {
 
 	@Id
-	@GeneratedValue(strategy=GenerationType.IDENTITY)
 	private Integer id;
 	
 	@Column(nullable=false)


### PR DESCRIPTION
Uklonio sam generisanje Id-a u GrupaIntervencija JPA, jer se na frontend-u pomoću getnextid() metode dobija sledeci id i onda se vrsi post metoda. Iz tog razloga sam dodao getNextId() metodu u rest kontroleru koja odgovara na zahtev getnextid() metode sa frontend-a. Na taj način su uradjeni i ostali rest kontroleri.